### PR TITLE
cache downloaded packages only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 ## Cache composer bits
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 ## PHP versions we test against
 php:


### PR DESCRIPTION
Caching the whole Composer `cache` directory means to cache Packagist
metadata too which become stale more often.