### PR TITLE
make some classes final

### DIFF
--- a/src/Definition/AccessToken.php
+++ b/src/Definition/AccessToken.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Definition;
 
-class AccessToken implements Token
+final class AccessToken implements Token
 {
     /**
      * @var string

--- a/src/Definition/ConsumerKey.php
+++ b/src/Definition/ConsumerKey.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Definition;
 
-class ConsumerKey
+final class ConsumerKey
 {
     /**
      * @var string

--- a/src/Definition/ConsumerSecret.php
+++ b/src/Definition/ConsumerSecret.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Definition;
 
-class ConsumerSecret
+final class ConsumerSecret
 {
     /**
      * @var string

--- a/src/Definition/RequestToken.php
+++ b/src/Definition/RequestToken.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Definition;
 
-class RequestToken implements Token
+final class RequestToken implements Token
 {
     /**
      * @var string

--- a/src/Definition/TokenSecret.php
+++ b/src/Definition/TokenSecret.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Definition;
 
-class TokenSecret
+final class TokenSecret
 {
     /**
      * @var string

--- a/src/Signature/HmacMd5Signature.php
+++ b/src/Signature/HmacMd5Signature.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Signature;
 
-class HmacMd5Signature extends HmacSignature
+final class HmacMd5Signature extends HmacSignature
 {
     protected function getHashingAlgorithm()
     {

--- a/src/Signature/HmacSha1Signature.php
+++ b/src/Signature/HmacSha1Signature.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Signature;
 
-class HmacSha1Signature extends HmacSignature
+final class HmacSha1Signature extends HmacSignature
 {
     protected function getHashingAlgorithm()
     {

--- a/src/Signature/HmacSha256Signature.php
+++ b/src/Signature/HmacSha256Signature.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Signature;
 
-class HmacSha256Signature extends HmacSignature
+final class HmacSha256Signature extends HmacSignature
 {
     protected function getHashingAlgorithm()
     {

--- a/src/Signature/HmacSha384Signature.php
+++ b/src/Signature/HmacSha384Signature.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Signature;
 
-class HmacSha384Signature extends HmacSignature
+final class HmacSha384Signature extends HmacSignature
 {
     protected function getHashingAlgorithm()
     {

--- a/src/Signature/HmacSha512Signature.php
+++ b/src/Signature/HmacSha512Signature.php
@@ -2,7 +2,7 @@
 
 namespace ApiClients\Tools\Psr7\Oauth1\Signature;
 
-class HmacSha512Signature extends HmacSignature
+final class HmacSha512Signature extends HmacSignature
 {
     protected function getHashingAlgorithm()
     {


### PR DESCRIPTION
There is no need to be able to extend these classes. Making them final
allows for easier refactoring in the future as you will not have to
worry about breaking BC.