### PR TITLE
Use current HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,41 +6,35 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
--## PHP versions we test against for current composer dependancies
- -php:
- -  - 7.0
- -  - 7.1
- -  - nightly
+ ## PHP versions we test against for current composer dependancies
+php:
+  - 7.0
+  - 7.1
+  - nightly
+## environment variables, one build is created for each
+env:
+  - dependencies=lowest
+  - dependencies=current
+  - dependencies=highest
 
 ## Build matrix for PHP versions we test against with lowest and highest possible targets
 matrix:
   include:
-    - php: 7.0
-      env: dependencies=lowest
-    - php: 7.1
-      env: dependencies=lowest
-    - php: nightly
-      env: dependencies=lowest
     - php: hhvm
       sudo: true
       dist: trusty
       group: edge # until the next major travis stable update
       env: dependencies=lowest
-    - php: 7.0
-      env: dependencies=highest
-    - php: 7.1
-      env: dependencies=highest
-    - php: nightly
-      env: dependencies=highest
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next major travis stable update
+      env: dependencies=current
     - php: hhvm
       sudo: true
       dist: trusty
       group: edge # until the next major travis stable update
       env: dependencies=highest
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next major travis stable update
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,7 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-## PHP versions we test against
-php:
-  - 7.0
-  - 7.1
-  - nightly
-  - hhvm
-
-## Build matrix for lowest and highest possible targets
+## Build matrix for PHP versions we test against with lowest and highest possible targets
 matrix:
   include:
     - php: 7.0
@@ -23,6 +16,9 @@ matrix:
     - php: nightly
       env: dependencies=lowest
     - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next major travis stable update
       env: dependencies=lowest
     - php: 7.0
       env: dependencies=highest
@@ -31,6 +27,9 @@ matrix:
     - php: nightly
       env: dependencies=highest
     - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next major travis stable update
       env: dependencies=highest
   allow_failures:
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
   allow_failures:
     - php: hhvm
 
+before_install:
+  # Force hhvm PHP 7 mode
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo hhvm.php7.all=1 >> /etc/hhvm/php.ini; fi
+
 ## Install or update dependencies
 install:
   #- composer validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
 install:
   #- composer validate
   - composer config --unset platform.php
-  - if [ -z "$dependencies" ]; then composer install --prefer-dist; fi;
+  - if [ "$dependencies" = "current" ]; then composer install --prefer-dist; fi;
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
   - if [ "$dependencies" = "highest" ]; then composer update --prefer-dist -n; fi;
   - composer show

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
+-## PHP versions we test against for current composer dependancies
+ -php:
+ -  - 7.0
+ -  - 7.1
+ -  - nightly
+
 ## Build matrix for PHP versions we test against with lowest and highest possible targets
 matrix:
   include:
@@ -31,6 +37,10 @@ matrix:
       dist: trusty
       group: edge # until the next major travis stable update
       env: dependencies=highest
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next major travis stable update
   allow_failures:
     - php: hhvm
 


### PR DESCRIPTION
This provides the current HHVM version (3.17.1 as of this PR) and will track with each release (i.e. will be 3.18 when 3.18 is released).

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/

Also you don't need to specify php versions when you put them in the build matrix

Note: HHVM php 7 mode currently has an issue that messes up composer under php 7 mode, see https://github.com/facebook/hhvm/issues/7198 and we have to specify HHVM PHP 7 mode since the project composer.json specifies only PHP 7+